### PR TITLE
Update trip date display

### DIFF
--- a/src/pages/TripCreate.tsx
+++ b/src/pages/TripCreate.tsx
@@ -26,6 +26,17 @@ export const TripCreate: React.FC = () => {
   const [loading, setLoading] = useState(false);
   const [error, setError] = useState<string | null>(null);
 
+  const formatKoreanDateLabel = (dateString: string) => {
+    if (!dateString) return '';
+    const [year, month, day] = dateString.split('-');
+    const date = new Date(Number(year), Number(month) - 1, Number(day));
+    const weekdays = ['일', '월', '화', '수', '목', '금', '토'];
+    const weekday = weekdays[date.getDay()];
+    const mm = month.padStart(2, '0');
+    const dd = day.padStart(2, '0');
+    return `${year}.${mm}.${dd}.${weekday}`;
+  };
+
   const countries = [
     '대한민국', '일본', '중국', '미국', '영국', '프랑스', '독일', '이탈리아',
     '스페인', '캐나다', '호주', '태국', '베트남', '싱가포르', '말레이시아',
@@ -254,6 +265,11 @@ export const TripCreate: React.FC = () => {
                   onChange={(e) => setFormData({ ...formData, start_date: e.target.value })}
                   className="w-full px-4 py-3 bg-glass-light backdrop-blur-sm border border-white/20 rounded-xl text-white focus:outline-none focus:border-primary-300 focus:ring-1 focus:ring-primary-300 touch-optimized transition-all text-numeric"
                 />
+                {formData.start_date && (
+                  <div className="text-xs-ko text-white/60 mt-1">
+                    {formatKoreanDateLabel(formData.start_date)}
+                  </div>
+                )}
               </div>
               <div>
                 <label className="block text-white text-sm-ko font-medium mb-2 tracking-ko-normal">
@@ -266,6 +282,11 @@ export const TripCreate: React.FC = () => {
                   min={formData.start_date}
                   className="w-full px-4 py-3 bg-glass-light backdrop-blur-sm border border-white/20 rounded-xl text-white focus:outline-none focus:border-primary-300 focus:ring-1 focus:ring-primary-300 touch-optimized transition-all text-numeric"
                 />
+                {formData.end_date && (
+                  <div className="text-xs-ko text-white/60 mt-1">
+                    {formatKoreanDateLabel(formData.end_date)}
+                  </div>
+                )}
               </div>
             </div>
 

--- a/src/pages/TripDetail.tsx
+++ b/src/pages/TripDetail.tsx
@@ -190,9 +190,14 @@ export const TripDetail: React.FC = () => {
           >
             {/* Header with Title and Edit Button */}
             <div className="flex items-center justify-between mb-4">
-              <h1 className="text-xl md:text-2xl lg:text-3xl font-bold text-white moonwave-glow break-words">
-                {trip.title}
-              </h1>
+              <div>
+                <h1 className="text-xl md:text-2xl lg:text-3xl font-bold text-white moonwave-glow break-words">
+                  {trip.title}
+                </h1>
+                <p className="text-white/60 text-sm mt-1">
+                  {formatDate(trip.start_date)} ~ {formatDate(trip.end_date)}
+                </p>
+              </div>
               <WaveButton
                 variant="ghost"
                 size="sm"

--- a/src/pages/TripDetail.tsx
+++ b/src/pages/TripDetail.tsx
@@ -121,6 +121,17 @@ export const TripDetail: React.FC = () => {
     });
   };
 
+  const formatKoreanDateLabel = (dateString: string) => {
+    if (!dateString) return '';
+    const [year, month, day] = dateString.split('-');
+    const date = new Date(Number(year), Number(month) - 1, Number(day));
+    const weekdays = ['일', '월', '화', '수', '목', '금', '토'];
+    const weekday = weekdays[date.getDay()];
+    const mm = month.padStart(2, '0');
+    const dd = day.padStart(2, '0');
+    return `${year}.${mm}.${dd}.${weekday}`;
+  };
+
   const getTripDuration = () => {
     const start = new Date(trip.start_date);
     const end = new Date(trip.end_date);
@@ -195,7 +206,7 @@ export const TripDetail: React.FC = () => {
                   {trip.title}
                 </h1>
                 <p className="text-white/60 text-sm mt-1">
-                  {formatDate(trip.start_date)} ~ {formatDate(trip.end_date)}
+                  {formatKoreanDateLabel(trip.start_date)} ~ {formatKoreanDateLabel(trip.end_date)}
                 </p>
               </div>
               <WaveButton

--- a/src/pages/TripEdit.tsx
+++ b/src/pages/TripEdit.tsx
@@ -36,6 +36,17 @@ export const TripEdit: React.FC = () => {
     '인도네시아', '필리핀', '인도', '브라질', '아르헨티나', '기타'
   ];
 
+  const formatKoreanDateLabel = (dateString: string) => {
+    if (!dateString) return '';
+    const [year, month, day] = dateString.split('-');
+    const date = new Date(Number(year), Number(month) - 1, Number(day));
+    const weekdays = ['일', '월', '화', '수', '목', '금', '토'];
+    const weekday = weekdays[date.getDay()];
+    const mm = month.padStart(2, '0');
+    const dd = day.padStart(2, '0');
+    return `${year}.${mm}.${dd}.${weekday}`;
+  };
+
   // 기존 여행 데이터 로드
   useEffect(() => {
     const loadTrip = async () => {
@@ -408,6 +419,11 @@ export const TripEdit: React.FC = () => {
                   onChange={(e) => setFormData({ ...formData, start_date: e.target.value })}
                   className="w-full px-4 py-3 bg-glass-light backdrop-blur-sm border border-white/20 rounded-xl text-white focus:outline-none focus:border-primary-300 focus:ring-1 focus:ring-primary-300 touch-optimized transition-all text-numeric"
                 />
+                {formData.start_date && (
+                  <div className="text-xs-ko text-white/60 mt-1">
+                    {formatKoreanDateLabel(formData.start_date)}
+                  </div>
+                )}
               </div>
               <div>
                 <label className="block text-white text-sm-ko font-medium mb-2 tracking-ko-normal">
@@ -420,6 +436,11 @@ export const TripEdit: React.FC = () => {
                   min={formData.start_date}
                   className="w-full px-4 py-3 bg-glass-light backdrop-blur-sm border border-white/20 rounded-xl text-white focus:outline-none focus:border-primary-300 focus:ring-1 focus:ring-primary-300 touch-optimized transition-all text-numeric"
                 />
+                {formData.end_date && (
+                  <div className="text-xs-ko text-white/60 mt-1">
+                    {formatKoreanDateLabel(formData.end_date)}
+                  </div>
+                )}
               </div>
             </div>
 


### PR DESCRIPTION
Add Korean formatted date labels to TripDetail, TripCreate, and TripEdit screens for improved date visibility.

---
<a href="https://cursor.com/background-agent?bcId=bc-a7452d53-d4f4-4739-8a7d-0da400ee8f1d">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-a7452d53-d4f4-4739-8a7d-0da400ee8f1d">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

