### PR TITLE
Deploy to vercel with json parse error

### DIFF
--- a/vercel.json
+++ b/vercel.json
@@ -6,7 +6,7 @@
 
   "rewrites": [
     {
-      "source": "^/(?!assets/|manifest\.json$|sw\.js$|moonwave-icon\.svg$).*$",
+      "source": "^/(?!assets/|manifest\\.json$|sw\\.js$|moonwave-icon\\.svg$).*$",
       "destination": "/index.html"
     }
   ],


### PR DESCRIPTION
Fixes JSON parsing error in `vercel.json` by correctly escaping backslashes in regex.

---
<a href="https://cursor.com/background-agent?bcId=bc-5891bf38-8347-493c-8117-7a071ebca48f">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-5891bf38-8347-493c-8117-7a071ebca48f">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

