### PR TITLE
Deploy to vercel with vercel.json error

### DIFF
--- a/vercel.json
+++ b/vercel.json
@@ -5,9 +5,7 @@
   "framework": "vite",
 
   "rewrites": [
-    {
-      "destination": "/index.html"
-    }
+    { "source": "/(.*)", "destination": "/index.html" }
   ],
 
   "headers": [


### PR DESCRIPTION
Add `source` property to `rewrites` in `vercel.json` to fix Vercel deployment error.

---
<a href="https://cursor.com/background-agent?bcId=bc-f6947884-0262-48ab-8e32-fd0fd1184e4d">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-f6947884-0262-48ab-8e32-fd0fd1184e4d">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

