### PR TITLE
Fix module script mime type error

### DIFF
--- a/vercel.json
+++ b/vercel.json
@@ -5,6 +5,11 @@
   "framework": "vite",
 
   "rewrites": [
+    { "source": "/assets/(.*)", "destination": "/assets/$1" },
+    { "source": "/sw.js", "destination": "/sw.js" },
+    { "source": "/manifest.json", "destination": "/manifest.json" },
+    { "source": "/moonwave-icon.svg", "destination": "/moonwave-icon.svg" },
+    { "source": "/favicon.ico", "destination": "/favicon.ico" },
     { "source": "/(.*)", "destination": "/index.html" }
   ],
 


### PR DESCRIPTION
Update Vercel rewrites to correctly serve static assets and fix module script MIME type errors.

The previous `vercel.json` configuration redirected all requests, including those for JavaScript modules and other static assets, to `index.html`. This caused the server to respond with `text/html` for module scripts, leading to `Failed to load module script` errors due to strict MIME type checking. This PR adds specific rewrite rules to ensure static files are served directly before the SPA fallback.

---
<a href="https://cursor.com/background-agent?bcId=bc-4fc8e853-3ad9-4dac-b293-9c71e45fe2dd">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-4fc8e853-3ad9-4dac-b293-9c71e45fe2dd">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

