### PR TITLE
Fix module script mime type error

### DIFF
--- a/vite.config.ts
+++ b/vite.config.ts
@@ -4,6 +4,7 @@ import path from 'path'
 
 // https://vitejs.dev/config/
 export default defineConfig({
+  base: process.env.VITE_BASE || '/',
   plugins: [react()],
   resolve: {
     alias: {
@@ -25,7 +26,6 @@ export default defineConfig({
   build: {
     outDir: 'dist',
     sourcemap: true,
-    base: '/moonwave/',
     rollupOptions: {
       output: {
         manualChunks: {


### PR DESCRIPTION
Corrects Vite `base` configuration to ensure proper module loading and prevent MIME type errors in production.

The previous `base` setting within `build` was causing incorrect asset paths in the production build, leading to module script requests returning `text/html` (likely a 404 fallback) instead of JavaScript. Moving `base` to the top-level and making it dynamic ensures correct asset resolution.

---
<a href="https://cursor.com/background-agent?bcId=bc-ce208820-8c98-4d14-812e-4760d1d9c036">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-ce208820-8c98-4d14-812e-4760d1d9c036">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

