### PR TITLE
Debug service worker and firebase errors

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,13 +1,10 @@
-# Copy to .env.local and fill with your Firebase Web App config
-# Find these in Firebase Console: Project Settings -> General -> Your apps (Web app)
-VITE_FIREBASE_API_KEY=
-VITE_FIREBASE_AUTH_DOMAIN=
-VITE_FIREBASE_PROJECT_ID=
-VITE_FIREBASE_STORAGE_BUCKET=
-VITE_FIREBASE_MESSAGING_SENDER_ID=
-VITE_FIREBASE_APP_ID=
-# Optional (only if you enabled Analytics)
-VITE_FIREBASE_MEASUREMENT_ID=
+VITE_FIREBASE_API_KEY=your_api_key
+VITE_FIREBASE_AUTH_DOMAIN=your_project.firebaseapp.com
+VITE_FIREBASE_PROJECT_ID=your_project_id
+VITE_FIREBASE_STORAGE_BUCKET=your_project.appspot.com
+VITE_FIREBASE_MESSAGING_SENDER_ID=your_sender_id
+VITE_FIREBASE_APP_ID=your_app_id
+VITE_FIREBASE_MEASUREMENT_ID=your_measurement_id
 
 # Application environment
 VITE_APP_ENV=development

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -44,6 +44,7 @@ jobs:
           VITE_FIREBASE_STORAGE_BUCKET: ${{ secrets.VITE_FIREBASE_STORAGE_BUCKET }}
           VITE_FIREBASE_MESSAGING_SENDER_ID: ${{ secrets.VITE_FIREBASE_MESSAGING_SENDER_ID }}
           VITE_FIREBASE_APP_ID: ${{ secrets.VITE_FIREBASE_APP_ID }}
+          VITE_FIREBASE_MEASUREMENT_ID: ${{ secrets.VITE_FIREBASE_MEASUREMENT_ID }}
           GITHUB_PAGES: 'true'
         run: |
           npm run build

--- a/public/sw.js
+++ b/public/sw.js
@@ -34,6 +34,11 @@ self.addEventListener('activate', (event) => {
 self.addEventListener('fetch', (event) => {
   const { request } = event;
 
+  // Early exit for non-GET requests: do not intercept or cache
+  if (request.method !== 'GET') {
+    return;
+  }
+
   // 자산 파일은 캐시 우선 (immutable)
   const assetsPrefix = new URL('assets/', SCOPE_URL).toString();
   const isAsset = request.url.startsWith(assetsPrefix);


### PR DESCRIPTION
Prevent service worker from caching non-GET requests and update Firebase environment variable handling.

This fixes the `TypeError: Failed to execute 'put' on 'Cache': Request method 'POST' is unsupported` by ensuring only GET requests are cached. It also addresses missing Firebase environment variables by providing a clear `.env.example` and ensuring all necessary variables are passed in CI/CD.

---
<a href="https://cursor.com/background-agent?bcId=bc-7cefa74a-491a-4421-97ad-d694fe012fe6">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-7cefa74a-491a-4421-97ad-d694fe012fe6">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

