### PR TITLE
Analyze 404 resource loading errors

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -43,7 +43,6 @@ jobs:
           VITE_FIREBASE_MESSAGING_SENDER_ID: ${{ secrets.VITE_FIREBASE_MESSAGING_SENDER_ID }}
           VITE_FIREBASE_APP_ID: ${{ secrets.VITE_FIREBASE_APP_ID }}
           VITE_FIREBASE_MEASUREMENT_ID: ${{ secrets.VITE_FIREBASE_MEASUREMENT_ID }}
-          GITHUB_PAGES: 'true'
         run: |
           npm run build
           # SPA fallback for direct deep links on GitHub Pages
@@ -57,3 +56,4 @@ jobs:
           publish_branch: gh-pages
           commit_message: Deploy to gh-pages
           enable_jekyll: false
+          cname: travel.moonwave.kr

--- a/public/sw.js
+++ b/public/sw.js
@@ -1,4 +1,4 @@
-const CACHE_NAME = 'moonwave-travel-v1.0.2';
+const CACHE_NAME = 'moonwave-travel-v1.0.3';
 const SCOPE_URL = new URL(self.registration.scope);
 
 const PRECACHE_URLS = [


### PR DESCRIPTION
Corrects asset 404s by aligning Vite's base path with the custom domain deployment on GitHub Pages and updating the service worker cache.

The CI workflow was building with `GITHUB_PAGES: 'true'`, which incorrectly set Vite's `base` to `/Travel_v2.0/`. This caused assets to be requested from the wrong subpath, leading to 404s on a custom domain deployed at the root. This PR removes the `GITHUB_PAGES` environment variable from the CI, ensuring Vite builds with `base: '/'` for root deployment, and updates the service worker cache version to prevent stale asset requests.

---
<a href="https://cursor.com/background-agent?bcId=bc-9872a5dd-650e-4bb1-8e7d-b8159fcd2d6b">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-9872a5dd-650e-4bb1-8e7d-b8159fcd2d6b">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

